### PR TITLE
Raise error if force push fails rather than modify remote URL

### DIFF
--- a/git_build_branch/branch_builder.py
+++ b/git_build_branch/branch_builder.py
@@ -249,18 +249,8 @@ def force_push(git, branch):
     try:
         git.push('origin', branch, '--force')
     except sh.ErrorReturnCode_128 as e:
-        # oops we're using a read-only URL, so change to the suggested url
-        try:
-            line = sh.grep(git.remote("-v"),
-                           '-E', r'^origin.(https|git)://github\.com/.*\(push\)$')
-        except sh.ErrorReturnCode_1:
-            raise e
-        old_url = line.strip().split()[1]
-        prefix = "git" if old_url.startswith("git:") else "https"
-        new_url = old_url.replace(prefix + "://github.com/", "git@github.com:")
-        print("    {} -> {}".format(old_url, new_url))
-        git.remote('set-url', 'origin', new_url)
-        git.push('origin', branch, '--force')
+        print(red("Failed to force push to origin. Please check your remote URL and ensure it accepts writes."))
+        raise e
 
 
 def format_cwd(cwd):

--- a/git_build_branch/branch_builder.py
+++ b/git_build_branch/branch_builder.py
@@ -248,9 +248,9 @@ def print_conflicts(branch, config, git):
 def force_push(git, branch):
     try:
         git.push('origin', branch, '--force')
-    except sh.ErrorReturnCode_128 as e:
+    except sh.ErrorReturnCode_128:
         print(red("Failed to force push to origin. Please check your remote URL and ensure it accepts writes."))
-        raise e
+        raise
 
 
 def format_cwd(cwd):


### PR DESCRIPTION
After changing my GitHub API token, I was triggering the force push to fail in this method because it needed a prompt, which resulted in the `except` case modifying my remote url to the SSH format in a last ditch effort. This was frustrating to have my remote URL get modified, and felt out of scope of what this tool should do. If the operator's set remote URL fails, we should just raise the error and inform them that we were unable to force push.