### PR TITLE
Upgrade `sh` via path of least resistance

### DIFF
--- a/git_build_branch/branch_builder.py
+++ b/git_build_branch/branch_builder.py
@@ -93,7 +93,7 @@ def fetch_remote(base_config, path, name="origin"):
 
 
 def remote_url(git, remote, original="origin"):
-    origin_url = sh.grep(git.remote("-v"), original).split()[1]
+    origin_url = sh.grep(original, _in=git.remote("-v")).split()[1]
     repo_name = origin_url.rsplit("/", 1)[1]
     return "https://github.com/{}/{}".format(remote, repo_name)
 
@@ -103,7 +103,7 @@ def sync_local_copies(config, path, push=True):
     unpushed_branches = []
 
     def _count_commits(compare_spec):
-        return int(sh.wc(git.log(compare_spec, '--oneline', _piped=True), '-l'))
+        return int(sh.wc('-l', _in=git.log(compare_spec, '--oneline', _piped=True)))
 
     for path, config in base_config.span_configs((path,)):
         git = get_git(path)

--- a/git_build_branch/branch_builder.py
+++ b/git_build_branch/branch_builder.py
@@ -27,6 +27,10 @@ from .gitutils import (  # noqa E402
 
 from .sh_verbose import ShVerbose  # noqa E402
 
+# HACK: temporary solution to revert to v1 behavior of sh
+# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
+sh = sh.bake(_return_cmd=True)
+
 
 class BranchConfig(jsonobject.JsonObject):
     trunk = jsonobject.StringProperty()

--- a/git_build_branch/gitutils.py
+++ b/git_build_branch/gitutils.py
@@ -41,7 +41,7 @@ class OriginalBranch(object):
 def git_current_branch(git=None):
     git = git or get_git()
     grep = get_grep()
-    branch = grep(git.branch(), '^* ').strip()[2:]
+    branch = grep('^*', _in=git.branch()).strip()[2:]
     if branch.startswith('('):
         branch = git.log('--pretty=oneline', n=1).strip().split(' ')[0]
     return branch
@@ -49,7 +49,7 @@ def git_current_branch(git=None):
 
 def git_recent_tags(grep_string="production-deploy", path=None):
     git, grep, tail = get_git(path), get_grep(), get_tail()
-    last_tags = tail(grep(git.tag('--sort=committerdate'), grep_string), n=4)
+    last_tags = tail(_in=grep(grep_string, _in=git.tag('--sort=committerdate')), n=4)
     return last_tags
 
 
@@ -168,7 +168,7 @@ def git_bisect_merge_conflict(branch1, branch2, git=None):
                     txt = git.bisect('bad')
             try:
                 # txt has a line that's like "<commit> is the first bad commit"
-                return grep(txt, ' is the first bad commit$').strip().split(' ')[0]
+                return grep(' is the first bad commit$', _in=txt).strip().split(' ')[0]
             except sh.ErrorReturnCode_1:
                 raise Exception('Error finding offending commit: '
                                 '"^commit" does not match\n{}'.format(txt))

--- a/git_build_branch/gitutils.py
+++ b/git_build_branch/gitutils.py
@@ -49,7 +49,7 @@ def git_current_branch(git=None):
 
 def git_recent_tags(grep_string="production-deploy", path=None):
     git, grep, tail = get_git(path), get_grep(), get_tail()
-    last_tags = tail(_in=grep(grep_string, _in=git.tag('--sort=committerdate')), n=4)
+    last_tags = tail(n=4, _in=grep(grep_string, _in=git.tag('--sort=committerdate')))
     return last_tags
 
 

--- a/git_build_branch/gitutils.py
+++ b/git_build_branch/gitutils.py
@@ -5,6 +5,10 @@ import sh
 
 from .sh_verbose import ShVerbose
 
+# HACK: temporary solution to revert to v1 behavior of sh
+# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
+sh = sh.bake(_return_cmd=True)
+
 
 def get_git(path=None):
     return sh.git.bake(_tty_out=False, _cwd=path)

--- a/git_build_branch/safe_commit_files.py
+++ b/git_build_branch/safe_commit_files.py
@@ -19,7 +19,7 @@ git = get_git()
 
 
 def get_branch():
-    branch = sh.sed(grep(git.branch(), "^\\*"), "s/* //")
+    branch = sh.sed("s/* //", _in=grep("^\\*", _in=git.branch()))
     return branch.stdout.strip().decode()
 
 
@@ -41,7 +41,7 @@ def main():
 
         git.add(*files)
         try:
-            staged = sh.grep(git.diff("--staged", "--stat"), "|")
+            staged = sh.grep("|", _in=git.diff("--staged", "--stat"))
         except ErrorReturnCode:
             print("You have no changes to commit.")
             exit(1)

--- a/git_build_branch/safe_commit_files.py
+++ b/git_build_branch/safe_commit_files.py
@@ -10,6 +10,10 @@ from .checkyaml import checkyaml, YamlError
 from .gitutils import get_git, get_grep
 from .sh_verbose import ShVerbose
 
+# HACK: temporary solution to revert to v1 behavior of sh
+# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
+sh = sh.bake(_return_cmd=True)
+
 grep = get_grep()
 git = get_git()
 

--- a/git_build_branch/sh_verbose.py
+++ b/git_build_branch/sh_verbose.py
@@ -5,6 +5,10 @@ import sys
 
 import sh
 
+# HACK: temporary solution to revert to v1 behavior of sh
+# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
+sh = sh.bake(_return_cmd=True)
+
 
 def format_cwd(cwd):
     return os.path.join(cwd) if cwd else '.'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -82,7 +82,7 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-sh==1.14.3
+sh==2.0.4
     # via git-build-branch (setup.py)
 six==1.16.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'Click>=7.0',
     'gevent>=1.4.0',
     'jsonobject>=0.9.9',
-    'sh>=1.0.9',
+    'sh>=2.0.0',
     'PyYAML>=5.1',
     'contextlib2>=0.5.5',
 ]


### PR DESCRIPTION
### Context

This upgrade is necessary because `commcare-hq` is now using `sh==2.0.3`, and most developers do not run `./scripts/rebuildstaging` from a separate virtualenv, which results in errors when running `git-build-branch` with v2 of `sh`.

### Details

[The migration strategy](https://github.com/amoffat/sh/blob/develop/MIGRATION.md) for v1 -> v2 of `sh` details workarounds and fixes for issues when upgrading.

The first commit uses the [workaround](https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string) mentioned for returning strings instead of command instances, and should only serve as a temporary fix.

The second commit fixes places that were relying on the behavior that automatically pipes input into the command if the first argument is an instance of `RunningCommand` which as been changed in v2. We now need to use the `_in=` argument to specify input for a command.

### Testing

In a separate virtualenv, I ran `pip install -e .` from the `git-build-branch` repo, activated that virtualenv in `commcare-hq`, and ran `./scripts/rebuildstaging` and it worked as expected.