### PR TITLE
Revert "Upgrade `sh` via path of least resistance"

### DIFF
--- a/git_build_branch/branch_builder.py
+++ b/git_build_branch/branch_builder.py
@@ -27,10 +27,6 @@ from .gitutils import (  # noqa E402
 
 from .sh_verbose import ShVerbose  # noqa E402
 
-# HACK: temporary solution to revert to v1 behavior of sh
-# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
-sh = sh.bake(_return_cmd=True)
-
 
 class BranchConfig(jsonobject.JsonObject):
     trunk = jsonobject.StringProperty()
@@ -93,7 +89,7 @@ def fetch_remote(base_config, path, name="origin"):
 
 
 def remote_url(git, remote, original="origin"):
-    origin_url = sh.grep(original, _in=git.remote("-v")).split()[1]
+    origin_url = sh.grep(git.remote("-v"), original).split()[1]
     repo_name = origin_url.rsplit("/", 1)[1]
     return "https://github.com/{}/{}".format(remote, repo_name)
 
@@ -103,7 +99,7 @@ def sync_local_copies(config, path, push=True):
     unpushed_branches = []
 
     def _count_commits(compare_spec):
-        return int(sh.wc('-l', _in=git.log(compare_spec, '--oneline', _piped=True)))
+        return int(sh.wc(git.log(compare_spec, '--oneline', _piped=True), '-l'))
 
     for path, config in base_config.span_configs((path,)):
         git = get_git(path)

--- a/git_build_branch/safe_commit_files.py
+++ b/git_build_branch/safe_commit_files.py
@@ -10,16 +10,12 @@ from .checkyaml import checkyaml, YamlError
 from .gitutils import get_git, get_grep
 from .sh_verbose import ShVerbose
 
-# HACK: temporary solution to revert to v1 behavior of sh
-# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
-sh = sh.bake(_return_cmd=True)
-
 grep = get_grep()
 git = get_git()
 
 
 def get_branch():
-    branch = sh.sed("s/* //", _in=grep("^\\*", _in=git.branch()))
+    branch = sh.sed(grep(git.branch(), "^\\*"), "s/* //")
     return branch.stdout.strip().decode()
 
 
@@ -41,7 +37,7 @@ def main():
 
         git.add(*files)
         try:
-            staged = sh.grep("|", _in=git.diff("--staged", "--stat"))
+            staged = sh.grep(git.diff("--staged", "--stat"), "|")
         except ErrorReturnCode:
             print("You have no changes to commit.")
             exit(1)

--- a/git_build_branch/sh_verbose.py
+++ b/git_build_branch/sh_verbose.py
@@ -5,10 +5,6 @@ import sys
 
 import sh
 
-# HACK: temporary solution to revert to v1 behavior of sh
-# see https://github.com/amoffat/sh/blob/develop/MIGRATION.md#return-value-now-a-true-string
-sh = sh.bake(_return_cmd=True)
-
 
 def format_cwd(cwd):
     return os.path.join(cwd) if cwd else '.'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -82,7 +82,7 @@ rfc3986==2.0.0
     # via twine
 rich==12.5.1
     # via twine
-sh==2.0.4
+sh==1.14.3
     # via git-build-branch (setup.py)
 six==1.16.0
     # via

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = [
     'Click>=7.0',
     'gevent>=1.4.0',
     'jsonobject>=0.9.9',
-    'sh>=2.0.0',
+    'sh>=1.0.9',
     'PyYAML>=5.1',
     'contextlib2>=0.5.5',
 ]


### PR DESCRIPTION
Reverts dimagi/git-build-branch#9

I'm a dingdong and messed up with release tags. My plan is to revert this PR, bump the version of `git-build-branch` to v0.1.14 and tag it (which it currently is on PyPI), and then re-merge this branch and bump again. 