### PR TITLE
Update contributing instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,10 +20,14 @@ Releasing
 ---------
 
 A reminder for the maintainers on how to make a release.
-Make sure all your changes are committed.
-Then, from master, run::
+Make sure all your changes are committed and merged into master.
+Then, from a new branch off of an up to date master, run::
 
 $ bump2version patch # possible: major / minor / patch
 $ git push --tags
+$ # create a PR
+
+Once merged into master, from master, run::
+
 $ make clean release
 


### PR DESCRIPTION
Since there are branch protection rules on master, instructions referencing pushing directly to master should be udpated.